### PR TITLE
Remove socket path if it exists

### DIFF
--- a/vm/main.ml
+++ b/vm/main.ml
@@ -14,6 +14,6 @@ let () =
     ]
     (fun _ -> ())
     usage_msg;
-  Sys.remove !socket_path;
+  if Sys.file_exists !socket_path then Sys.remove !socket_path;
   Dream.log "Starting listening on %s\n" !socket_path;
   Dream.run ~socket_path:!socket_path hello


### PR DESCRIPTION
Thanks for this repository, very useful for trying out the new docker extensions with an OCaml stack! This small change seemed to be necessary for the VM not to crash for me.